### PR TITLE
Change clippy check

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,9 +43,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           components: clippy
       - name: cargo clippy
-        uses: actions-rs/clippy-check@v1
+        uses: clechasseur/rs-clippy-check@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: ${{ matrix.toolchain }}
   doc:
     runs-on: ubuntu-latest
     name: nightly / doc


### PR DESCRIPTION
Previously I would see the following when running an action:

```text

Annotations
2 warnings
stable / clippy
The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/clippy-check@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
beta / clippy
The following actions uses node12 which is deprecated and will be forced to run on node16: actions-rs/clippy-check@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```